### PR TITLE
page description update

### DIFF
--- a/templates/_blocks/archive-timeline.ejs
+++ b/templates/_blocks/archive-timeline.ejs
@@ -1,8 +1,9 @@
 <% let lastTime = ''; %>
+<% let articles = 0; site.posts.forEach(function(post) { if (!post.hideInList) articles++;});%>
 <div class="archive-timeline-box">
   <div class="archive-timeline-title">
     <% if (site.posts.length > 0) {%>
-      <h2>非常好！目前共计<%= site.posts.length %>篇日志，继续努力！</h2>
+      <h2>非常好！目前共计<%= articles %>篇日志，继续努力！</h2>
     <% } else { %>
       <h2>您目前还没有记录日志哟~~~</h2>
     <% } %>
@@ -27,5 +28,4 @@
     </a>
   <% }%>
 </div>
-<% let articles = 0; site.posts.forEach(function(post) { if (!post.hideInList) articles++;});%>
 <%- include('./pagination', { logs: articles, pageSize: themeConfig.archivesPageSize, url: '/archives/page/', index: 5}) %>

--- a/templates/_blocks/head.ejs
+++ b/templates/_blocks/head.ejs
@@ -3,7 +3,6 @@
 <title><%= siteTitle %></title>
 <link rel="shortcut icon" href="<%= themeConfig.domain %>/favicon.ico?v=<%= site.utils.now %>">
 <link rel="stylesheet" href="<%= themeConfig.domain %>/styles/main.css">
-<meta name="description" content="<%- themeConfig.siteDescription %>" />
 
 <link rel="stylesheet" href="/media/fonts/font-awesome.css">
 <link href="//fonts.googleapis.com/css?family=Monda:300,300italic,400,400italic,700,700italic|Roboto Slab:300,300italic,400,400italic,700,700italic|Rosario:300,300italic,400,400italic,700,700italic|PT Mono:300,300italic,400,400italic,700,700italic&subset=latin,latin-ext" rel="stylesheet" type="text/css">

--- a/templates/_blocks/title.ejs
+++ b/templates/_blocks/title.ejs
@@ -27,9 +27,9 @@
           <% } %>
         <% } %>
       </span>
+      <span class="post-meta-divider">|</span>
     <% } %>
     <span class="meta-item">
-      <span class="post-meta-divider">|</span>
       <i class="fa fa-clock-o"></i>
       <span><%= stats.minutes %>分钟</span>
     </span>

--- a/templates/archives.ejs
+++ b/templates/archives.ejs
@@ -1,6 +1,7 @@
 <html>
   <head>
       <%- include('./_blocks/head', { siteTitle: themeConfig.siteName }) %>
+      <meta name="description" content="<%= themeConfig.siteDescription %>">
   </head>
   <body>
     <div class="head-top-line"></div>

--- a/templates/index.ejs
+++ b/templates/index.ejs
@@ -1,6 +1,7 @@
 <html>
   <head>
       <%- include('./_blocks/head', { siteTitle: themeConfig.siteName }) %>
+      <meta name="description" content="<%= themeConfig.siteDescription %>">
   </head>
   <body>
     <div class="head-top-line"></div>

--- a/templates/post.ejs
+++ b/templates/post.ejs
@@ -1,6 +1,8 @@
 <html>
   <head>
-      <%- include('./_blocks/head', { siteTitle: themeConfig.siteName }) %>
+    <%- include('./_blocks/head', { siteTitle: `${post.title} | ${themeConfig.siteName}` }) %>
+    <meta name="description" content="<%- post.title %>" />
+    <meta name="keywords" content="<%- post.tags.map(tag => tag.name).join(',') %>" />
   </head>
   <body>
     <div class="head-top-line"></div>

--- a/templates/tag.ejs
+++ b/templates/tag.ejs
@@ -1,6 +1,7 @@
 <html>
   <head>
       <%- include('./_blocks/head', { siteTitle: themeConfig.siteName }) %>
+      <meta name="description" content="<%= themeConfig.siteDescription %>">
   </head>
   <body>
     <div class="head-top-line"></div>

--- a/templates/tags.ejs
+++ b/templates/tags.ejs
@@ -1,6 +1,7 @@
 <html>
   <head>
       <%- include('./_blocks/head', { siteTitle: themeConfig.siteName }) %>
+      <meta name="description" content="<%= themeConfig.siteDescription %>">
   </head>
   <body>
     <div class="head-top-line"></div>


### PR DESCRIPTION
1. 修复 archive 页面统计的文章数（去掉了隐藏的文章，比如about 页面）
2. 修复基于 gitalk 创建 issue 页面时展示的标题和内容
3. 修复在手机浏览时，index 页面标题下面，没有标签的文章标题显示时左边会多出一个"|"，如下图
![image](https://user-images.githubusercontent.com/5220740/71956315-c8aa3c80-3225-11ea-8777-a79dde3af29a.png)
