### PR TITLE
站点子标题 更改为主题设置,添加博主说明

### DIFF
--- a/config.json
+++ b/config.json
@@ -30,6 +30,13 @@
       ]
     },
     {
+      "name": "subTitle",
+      "label": "子标题",
+      "group": "布局",
+      "value": "精于心，简于形",
+      "type": "input"
+    },
+    {
       "name": "bolgername",
       "label": "博主名称",
       "group": "布局",

--- a/config.json
+++ b/config.json
@@ -30,10 +30,17 @@
       ]
     },
     {
-      "name": "subTitle",
-      "label": "子标题",
+      "name": "bolgername",
+      "label": "博主名称",
       "group": "布局",
-      "value": "精于心，简于形",
+      "value": "仅适用 Gemini,Pisces 布局",
+      "type": "input"
+    },
+    {
+      "name": "bolgerjs",
+      "label": "博主介绍",
+      "group": "布局",
+      "value": "仅适用 Gemini,Pisces 布局",
       "type": "input"
     },
     {

--- a/templates/_blocks/header.ejs
+++ b/templates/_blocks/header.ejs
@@ -27,8 +27,8 @@
             </a>  
           <% } %>
         </div>
-        <% if (scheme !== 'mist' && site.customConfig.subTitle) {%>
-          <p class="subtitle"><%= site.customConfig.subTitle %></p>
+        <% if (scheme !== 'mist' && site.themeConfig.siteDescription) {%>
+          <p class="subtitle"><%= site.themeConfig.siteDescription %></p>
         <% } %>
       </div>
       <nav class="site-nav" id="site_nav">

--- a/templates/_blocks/header.ejs
+++ b/templates/_blocks/header.ejs
@@ -27,8 +27,8 @@
             </a>  
           <% } %>
         </div>
-        <% if (scheme !== 'mist' && site.themeConfig.siteDescription) {%>
-          <p class="subtitle"><%= site.themeConfig.siteDescription %></p>
+        <% if (scheme !== 'mist' && site.customConfig.subTitle) {%>
+          <p class="subtitle"><%= site.customConfig.subTitle %></p>
         <% } %>
       </div>
       <nav class="site-nav" id="site_nav">

--- a/templates/_blocks/site-meta.ejs
+++ b/templates/_blocks/site-meta.ejs
@@ -2,8 +2,8 @@
 <div class="sidebar-wrapper box-shadow-wrapper <%= (scheme === 'muse' || scheme === 'mist')?'':'bg-color' %>">
   <div class="sidebar-item">
     <img class="site-author-image right-motion" src="<%= site.customConfig.cdn %>/images/avatar.png"/>
-    <p class="site-author-name"><%= themeConfig.siteName %></p>
-    <p class="site-description right-motion"><%= site.themeConfig.siteDescription %></p>
+    <p class="site-author-name"><%= site.customConfig.bolgername %></p>
+    <p class="site-description right-motion"><%= site.customConfig.bolgerjs %></p>
   </div>
   <div class="sidebar-item side-item-stat right-motion">
     <div class="sidebar-item-box">


### PR DESCRIPTION
站点子标题更改为基础配置里的网站描述,
主题自定义内删除,添加 Gemini,Pisces 布局 博主头像下名称以及介绍 

简单修改,本地测试可以跑,不懂代码...

麻烦 检查一下..

![](https://developer-forum-online.cdn.bcebos.com/d77dd1ac-4e13-4c44-9c8e-0e555350dc77.png)

![](https://developer-forum-online.cdn.bcebos.com/38d0d4fa-766b-45e2-9417-901d42f5a22e.gif)