### PR TITLE
fix-资源引用多了个空格

### DIFF
--- a/templates/_blocks/after-body.ejs
+++ b/templates/_blocks/after-body.ejs
@@ -150,5 +150,5 @@
 <% } %>
 <%- include('./mouse-click') %>
 <% if (site.customConfig.bolgerjsplus) { %>
-<script src="<%= site.customConfig.cdn %> /media/js/cool.js"></script>
+<script src="<%= site.customConfig.cdn %>/media/js/cool.js"></script>
 <% } %>


### PR DESCRIPTION
导致开启CDN资源失效.且无法使用搜索功能