### PR TITLE
修改公式块默认字体

### DIFF
--- a/style-override.js
+++ b/style-override.js
@@ -83,7 +83,11 @@ const generateOverride = (params) => {
     }
     * {
         font-family: '${params.fontFamily}';
-    }`
+    }
+    .katex-block *{
+      font-family: 'KaTeX_Main';
+    }
+    `
   }
 
   if (params.fontSize && params.fontSize !== '') {


### PR DESCRIPTION
    .katex-block *{
      font-family: 'KaTeX_Main';
    }
使用后代选择器